### PR TITLE
Refactor getUniqueEvents- functions

### DIFF
--- a/src/lib/function.ts
+++ b/src/lib/function.ts
@@ -96,31 +96,11 @@ const getUniqueEventsByTag = (items: Event[]): Event[] => {
 
 //
 function getUniqueEventsById(events: Event[]): Event[] {
-  const uniqueEvents: Event[] = [];
-  const idSet: Set<string> = new Set();
-
-  events.forEach((event) => {
-    if (!idSet.has(event.id)) {
-      uniqueEvents.push(event);
-      idSet.add(event.id);
-    }
-  });
-
-  return uniqueEvents;
+  return [...new Set(events.map(({ id }) => id))];
 }
 
 const getUniqueEventsByPubkey = (events: Event[]): Event[] => {
-  const uniqueEvents: Event[] = [];
-  const pubkeySet: Set<string> = new Set();
-
-  events.forEach((event) => {
-    if (!pubkeySet.has(event.pubkey)) {
-      uniqueEvents.push(event);
-      pubkeySet.add(event.pubkey);
-    }
-  });
-
-  return uniqueEvents;
+  return [...new Set(events.map(({ pubkey }) => pubkey))];
 };
 
 export async function publishEvent(


### PR DESCRIPTION
Simplify `getUniqueEventsById` and `getUniqueEventsByPubkey`.

ref: https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Set#%E9%85%8D%E5%88%97%E3%81%8B%E3%82%89%E9%87%8D%E8%A4%87%E3%81%97%E3%81%9F%E8%A6%81%E7%B4%A0%E3%82%92%E5%8F%96%E3%82%8A%E9%99%A4%E3%81%8F